### PR TITLE
Add instructions for installing with Flatpak on any distro

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ Figure out the word before your guesses run out!
 
 Warble is inspired by (and not affiliated with) the recently popular online game Wordle (which itself is reminiscent of the late 80's game show Lingo). 
 
+## Install with Flatpak
+
+Even if you are not on elementary OS, you can install Warble from the elementary Flatpak repository
+```
+flatpak install https://flatpak.elementary.io/repo/appstream/com.github.avojak.warble.flatpakref
+```
+
 ## Install from Source
 
 You can install Warble by compiling from source. Here's the list of
@@ -51,7 +58,7 @@ $ sudo ninja -C build install
 $ com.github.avojak.warble
 ```
 
-### Flatpak
+### Build with Flatpak
 
 To test the Flatpak build with Flatpak Builder:
 


### PR DESCRIPTION
Warble can be installed on any distro by utilizing the Elementary Flatpak repository. Building from source is not required.