### PR TITLE
Respect the systems gtk_decoration_layout preference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ all: translations flatpak
 
 .PHONY: flatpak-init
 flatpak-init:
-	flatpak remote-add --if-not-exists --system $(ELEMENTARY_FLATPAK_REMOTE_NAME) $(ELEMENTARY_FLATPAK_REMOTE_URL)
+	flatpak remote-add --if-not-exists --user $(ELEMENTARY_FLATPAK_REMOTE_NAME) $(ELEMENTARY_FLATPAK_REMOTE_URL)
 	flatpak install -y --user $(ELEMENTARY_FLATPAK_REMOTE_NAME) io.elementary.Platform//$(ELEMENTARY_PLATFORM_VERSION) 
 	flatpak install -y --user $(ELEMENTARY_FLATPAK_REMOTE_NAME) io.elementary.Sdk//$(ELEMENTARY_PLATFORM_VERSION)
 
@@ -43,7 +43,7 @@ flatpak:
 
 .PHONY: flathub-init
 flathub-init:
-	flatpak remote-add --if-not-exists --system $(FLATHUB_FLATPAK_REMOTE_NAME) $(FLATHUB_FLATPAK_REMOTE_URL)
+	flatpak remote-add --if-not-exists --user $(FLATHUB_FLATPAK_REMOTE_NAME) $(FLATHUB_FLATPAK_REMOTE_URL)
 	flatpak install -y --user $(FLATHUB_FLATPAK_REMOTE_NAME) org.gnome.Platform//$(FLATHUB_PLATFORM_VERSION)
 	flatpak install -y --user $(FLATHUB_FLATPAK_REMOTE_NAME) org.gnome.Sdk//$(FLATHUB_PLATFORM_VERSION)
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ The officially supported method of installing Warble is via the flatpak, however
 | ------ | -------------- | ------- |
 | Snapcraft | `stable` | <a href="https://snapcraft.io/warble"><img src="https://badgennet-git-fork-vladimyr-snapcraft-badgen.vercel.app/snapcraft/v/warble/arm64/stable"></img></a> |
 | | `edge` | <a href="https://snapcraft.io/warble"><img src="https://badgennet-git-fork-vladimyr-snapcraft-badgen.vercel.app/snapcraft/v/warble/arm64/edge"></img></a> |
-| Fedora | `rawhide` | <a href="https://src.fedoraproject.org/rpms/warble/"><img src="https://img.shields.io/fedora/v/warble/rawhide"></img></a> |
-|  | `f36` | <a href="https://src.fedoraproject.org/rpms/warble/"><img src="https://img.shields.io/fedora/v/warble/f36"></img></a> |
-|  | `f35` | <a href="https://src.fedoraproject.org/rpms/warble/"><img src="https://img.shields.io/fedora/v/warble/f35"></img></a> |
+| Fedora | `rawhide` | [![Fedora Rawhide](https://repology.org/badge/version-for-repo/fedora_rawhide/warble.svg?header=Fedora%20Rawhide)](https://repology.org/project/warble/versions) |
+|  | `f36` | [![Fedora 36](https://repology.org/badge/version-for-repo/fedora_36/warble.svg?header=Fedora%2036)](https://repology.org/project/warble/versions) |
+|  | `f35` | [![Fedora 35](https://repology.org/badge/version-for-repo/fedora_35/warble.svg?header=Fedora%2035)](https://repology.org/project/warble/versions) |
+| AUR |  | [![AUR package](https://repology.org/badge/version-for-repo/aur/warble.svg?header=AUR)](https://repology.org/project/warble/versions) |
 
 ## Install from Source
 

--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -26,7 +26,11 @@ public class Warble.Widgets.HeaderBar : Hdy.HeaderBar {
             title: Constants.APP_NAME,
             show_close_button: true,
             has_subtitle: false,
-            decoration_layout: "close:" // Disable the maximize/restore button
+            // TODO: Revisit this when updating to GTK4 and removing libhandy.
+            // This shouldn't be necessary if using non-libhandy widgets and setting the header bar directly on
+            // the application window. But for now, this will have the effect of respecting the system positioning
+            // of the close button, while still hiding the maximize/restore button.
+            decoration_layout: Gtk.Settings.get_default ().gtk_decoration_layout.replace ("maximize", "").replace ("minimize", "")
         );
     }
 


### PR DESCRIPTION
Respects the system `gtk_decoration_layout` preference while still hiding the maximize/restore buttons.

Ideally the maximize/restore buttons would be automatically hidden since the application window sets `resizable: false`, however that doesn't seem to work with libhandy widgets. Added a TODO to revisit this when updating to GTK4 and removing libhandy.

In the meantime I'm not sure of a better way to handle this.

 elementary OS:
<img width="468" alt="Screen Shot 2022-06-10 at 11 33 25 AM" src="https://user-images.githubusercontent.com/3663899/173120904-8008df6c-d24e-4aa7-8cce-7db21abbef96.png">

Pop!_OS:
<img width="465" alt="Screen Shot 2022-06-10 at 11 33 37 AM" src="https://user-images.githubusercontent.com/3663899/173120917-7b1f7f35-cc6a-4130-b5db-718a9d743167.png">

Resolves #36 